### PR TITLE
Log container name when stopping the container fails

### DIFF
--- a/src/include/ABHelper.php
+++ b/src/include/ABHelper.php
@@ -175,13 +175,13 @@ class ABHelper {
             $stopTimer      = time();
             $dockerStopCode = $dockerClient->stopContainer($container['Name']);
             if ($dockerStopCode != 1) {
-                self::backupLog("Error while stopping container! Code: " . $dockerStopCode . " - trying 'docker stop' method", self::LOGLEVEL_WARN, true, true);
+                self::backupLog("Error while stopping container '" . $container['Name'] . "'! Code: " . $dockerStopCode . " - trying 'docker stop' method", self::LOGLEVEL_WARN, true, true);
                 $out = $code = null;
                 exec("docker stop " . escapeshellarg($container['Name']) . " -t 30", $out, $code);
                 if ($code == 0) {
                     self::backupLog("That _seemed_ to work.");
                 } else {
-                    self::backupLog("docker stop variant was unsuccessful as well! Docker said: " . implode(', ', $out), self::LOGLEVEL_ERR);
+                    self::backupLog("docker stop variant was unsuccessful as well when stopping '" . $container['Name']. "'! Docker said: " . implode(', ', $out), self::LOGLEVEL_ERR);
                 }
             } else {
                 self::backupLog("done! (took " . (time() - $stopTimer) . " seconds)", self::LOGLEVEL_INFO, true, true);


### PR DESCRIPTION
The current log messages don't include the container name, which can be less than helpful especially when they show up without context as Unraid notifications.

![image](https://github.com/user-attachments/assets/c3c3a54b-c5c9-4b75-8c5f-3236d2c8b6c1)

This PR adds the container name to the log messages when the container fails to stop, which makes it easier to identify which container is having an issue.