### PR TITLE
feat: add volume path mappings

### DIFF
--- a/appdata.backup.plg
+++ b/appdata.backup.plg
@@ -1,12 +1,12 @@
 <?xml version='1.0' standalone='yes'?>
 <!DOCTYPE PLUGIN [
         <!ENTITY name      "appdata.backup">
-        <!ENTITY author    "Robin Kluth">
-        <!ENTITY version   "2026.03.13">
-        <!ENTITY sha256    "6482aacddc1f006759695afcc123c7537e9003d3a2cfa3e198b88c4dedb05fb3">
+        <!ENTITY author    "Robin Kluth; Shaheen Gandhi">
+        <!ENTITY version   "2026.03.30">
+        <!ENTITY sha256    "2ed071ee17d7584d0e39fcc47f0c8d6ce05c63a779fac90e0b1c200d2dae6b51">
         <!ENTITY launch    "Settings/AB.Main">
         <!ENTITY plugdir   "/usr/local/emhttp/plugins/&name;">
-        <!ENTITY github    "Commifreak/unraid-appdata.backup">
+        <!ENTITY github    "visigoth/unraid-appdata.backup">
         <!ENTITY pluginURL "https://raw.githubusercontent.com/&github;/master/&name;.plg">
         ]>
 
@@ -16,6 +16,9 @@
     <CHANGES>
         <![CDATA[
         ➕New  🩹Fix 🔧Change
+
+###2026.03.30
+- ➕ Allow for mapping container volume paths.
 
 ###2026.03.13
 - 🩹 Fix UI alignment for container backup settings. [Issue 68](https://github.com/Commifreak/unraid-appdata.backup/issues/68)
@@ -279,7 +282,7 @@ _That will be the last update for today! I promise! 🍻_
             echo " &name; has been installed."
             echo " (previously known as ca.backup2)"
             echo ""
-            echo " 2022-2025, Robin Kluth"
+            echo " 2022-2025, Robin Kluth; Shaheen Gandhi"
             echo " Version: &version;"
             echo "----------------------------------------------------"
             echo ""

--- a/src/include/ABHelper.php
+++ b/src/include/ABHelper.php
@@ -345,7 +345,7 @@ class ABHelper {
 
         self::backupLog("Backup {$container['Name']} - Container Volumeinfo: " . print_r($container['Volumes'], true), self::LOGLEVEL_DEBUG);
 
-        $volumes = self::getContainerVolumes($container);
+        $volumes = self::getMappedContainerVolumes($container);
 
         $containerSettings = $abSettings->getContainerSpecificSettings($container['Name']);
 
@@ -519,6 +519,50 @@ class ABHelper {
      */
     public static function abortRequested() {
         return file_exists(ABSettings::$tempFolder . '/' . ABSettings::$stateFileAbort);
+    }
+
+    /**
+     * Helper to get mapped container volumes, applying path mappings if configured
+     * @param $container
+     * @param $skipExclusionCheck
+     * @return array
+     */
+    public static function getMappedContainerVolumes($container, $skipExclusionCheck = false) {
+        global $abSettings;
+
+        $volumes = self::getContainerVolumes($container, $skipExclusionCheck);
+
+        // Apply path mappings if configured
+        if (!empty($abSettings->volumePathMappings)) {
+            self::backupLog("Applying volume path mappings for {$container['Name']}", self::LOGLEVEL_DEBUG);
+
+            foreach ($volumes as $index => $volume) {
+                $originalVolume = $volume;
+
+                // Try each mapping - only the first match is applied
+                foreach ($abSettings->volumePathMappings as $mapping) {
+                    $from = $mapping['from'];
+                    $to = $mapping['to'];
+
+                    // Check if this volume starts with the 'from' path
+                    if (str_starts_with($volume, $from . '/') || $volume === $from) {
+                        // Replace the prefix
+                        if ($volume === $from) {
+                            $volume = $to;
+                        } else {
+                            $volume = $to . substr($volume, strlen($from));
+                        }
+
+                        self::backupLog("Mapped volume path: '$originalVolume' => '$volume'", self::LOGLEVEL_DEBUG);
+                        break; // Apply only the first matching mapping
+                    }
+                }
+
+                $volumes[$index] = $volume;
+            }
+        }
+
+        return $volumes;
     }
 
     /**

--- a/src/include/ABSettings.php
+++ b/src/include/ABSettings.php
@@ -80,6 +80,7 @@ class ABSettings {
     public string $successLogWanted = 'no';
     public string $updateLogWanted = 'no';
     public string $ignoreExclusionCase = 'no';
+    public array $volumePathMappings = [];
 
     public function __construct() {
 
@@ -107,6 +108,23 @@ class ABSettings {
                                     $newPaths[] = rtrim($path, '/');
                                 }
                                 $this->$key = $newPaths;
+                                break;
+                            case 'volumePathMappings':
+                                $mappings = [];
+                                $lines = explode("\r\n", $value);
+                                foreach ($lines as $line) {
+                                    $line = trim($line);
+                                    if (empty($line) || str_starts_with($line, '#')) {
+                                        continue; // Skip empty lines and comments
+                                    }
+                                    // Parse mapping in format: /original/path => /mapped/path
+                                    if (preg_match('/^(.+?)\s*=>\s*(.+)$/', $line, $matches)) {
+                                        $from = rtrim($matches[1], '/');
+                                        $to = rtrim($matches[2], '/');
+                                        $mappings[] = ['from' => $from, 'to' => $to];
+                                    }
+                                }
+                                $this->$key = $mappings;
                                 break;
                             case 'containerOrder':
                                 // HACK - if something goes wrong while we transfer the jQuery sortable data, the value here would NOT be an array. Better safe than sorry: Force to empty array if it isnt one.

--- a/src/pages/content/settings.php
+++ b/src/pages/content/settings.php
@@ -113,6 +113,11 @@ window.setTimeout(function() {
         exit;
     }
 
+    // Process volume path mappings to ensure proper format
+    if (isset($_POST['volumePathMappings']) && empty(trim($_POST['volumePathMappings']))) {
+        $_POST['volumePathMappings'] = '';
+    }
+
     //Hack the order string
     parse_str($_POST['containerOrder'], $containerOrder);
     if (empty($containerOrder)) {
@@ -305,6 +310,36 @@ if (($code ?? 0) != 0) {
         <p>The plugin detects every volume mapping within your set "appdata source(s)" as internal ones. Everything else
             is being detected as external.</p>
         <p>The list of volume mappings is directly read from your container configuration!</p>
+    </blockquote>
+
+    <dl>
+        <dt><b>Volume path mappings</b> <small>(optional)</small></dt>
+        <dd>
+            <div style="display: table; width: 300px;">
+                <textarea id="volumePathMappings" name="volumePathMappings"
+                         style="resize: vertical; width: 400px; height: 100px;"
+                         placeholder="/mnt/user/appdata => /mnt/snap_backup_source"><?php
+                    $mappingLines = [];
+                    foreach ($abSettings->volumePathMappings as $mapping) {
+                        $mappingLines[] = $mapping['from'] . ' => ' . $mapping['to'];
+                    }
+                    echo implode("\r\n", $mappingLines);
+                ?></textarea>
+            </div>
+        </dd>
+    </dl>
+
+    <blockquote class='inline_help'>
+        <p><b>Volume Path Mappings</b> allow you to transform container volume paths before backup processing.</p>
+        <p>This is useful when backing up from snapshots or alternative mount points. When a container's volume path
+           is processed, if it starts with a "from" path, it will be replaced with the corresponding "to" path.</p>
+        <p><b>Format:</b> One mapping per line, using the format: <code>/original/path => /mapped/path</code></p>
+        <p><b>Example:</b><br/>
+           <code>/mnt/user/appdata => /mnt/snap_backup_source</code><br/>
+           This would transform <code>/mnt/user/appdata/myapp</code> to <code>/mnt/snap_backup_source/myapp</code></p>
+        <p><b>Important:</b> Only the first matching mapping is applied to each path. Order your mappings from most specific to least specific.</p>
+        <p><b>Note:</b> The mapped paths are evaluated against your "Appdata source(s)" to determine if they're internal
+           or external volumes.</p>
     </blockquote>
 
     <dl>
@@ -596,19 +631,29 @@ HTML;
                 }
 
                 $image   = empty($container['Icon']) ? '/plugins/dynamix.docker.manager/images/question.png' : $container['Icon'];
-                $volumes = ABHelper::getContainerVolumes($container, true);
+                $originalVolumes = ABHelper::getContainerVolumes($container, true);
+                $mappedVolumes = ABHelper::getMappedContainerVolumes($container, true);
                 $containerSetting = $abSettings->getContainerSpecificSettings($container['Name'], false);
                 $realContainerSetting = print_r($abSettings->getContainerSpecificSettings($container['Name']), true);
 
-                if (empty($volumes)) {
+                if (empty($mappedVolumes)) {
                     $volumes = "<b>No volumes - container will NOT being backed up!</b>";
                 } else {
-                    foreach ($volumes as $index => $volume) {
-                        $excluded        = in_array($volume, $containerSetting['exclude']) ? ' - <abbr style="color: red; font-weight: bold;" title="Will not being backed up! See exclusions list below!">EXCLUDED!</abbr> ' : false;
-                        $internalVolume  = ABHelper::isVolumeWithinAppdata($volume);
-                        $volumes[$index] = '<span class="fa ' . (!$internalVolume ? 'fa-external-link' : 'fa-folder') . '"></span> <code style="cursor:pointer;" data-container="' . $container['Name'] . '" data-internal="' . ($internalVolume ? 'true' : 'false') . '" data-excluded="' . ($excluded ? 'true' : 'false') . '" onclick="addVolumeToExclude(this);">' . $volume . '</code>' . $excluded . '<span style="display: none;" class="multiVolumeWarn"> - <a target="_blank" href="https://forums.unraid.net/topic/137710-plugin-appdatabackup/?do=findComment&comment=1250363">used in multiple containers!</a></span>';
+                    $volumeDisplay = [];
+                    foreach ($mappedVolumes as $index => $mappedVolume) {
+                        $originalVolume = $originalVolumes[$index];
+                        $excluded = in_array($mappedVolume, $containerSetting['exclude']) ? ' - <abbr style="color: red; font-weight: bold;" title="Will not being backed up! See exclusions list below!">EXCLUDED!</abbr> ' : false;
+                        $internalVolume = ABHelper::isVolumeWithinAppdata($mappedVolume);
+                        
+                        // Show original path, and if different, show mapped path in parentheses
+                        $pathDisplay = $originalVolume;
+                        if ($originalVolume !== $mappedVolume) {
+                            $pathDisplay = $originalVolume . ' <span style="color: #888; font-style: italic;">(→ ' . $mappedVolume . ')</span>';
+                        }
+                        
+                        $volumeDisplay[] = '<span class="fa ' . (!$internalVolume ? 'fa-external-link' : 'fa-folder') . '"></span> <code style="cursor:pointer;" data-container="' . $container['Name'] . '" data-internal="' . ($internalVolume ? 'true' : 'false') . '" data-excluded="' . ($excluded ? 'true' : 'false') . '" data-original="' . htmlspecialchars($originalVolume) . '" data-mapped="' . htmlspecialchars($mappedVolume) . '" onclick="addVolumeToExclude(this);">' . $pathDisplay . '</code>' . $excluded . '<span style="display: none;" class="multiVolumeWarn"> - <a target="_blank" href="https://forums.unraid.net/topic/137710-plugin-appdatabackup/?do=findComment&comment=1250363">used in multiple containers!</a></span>';
                     }
-                    $volumes = implode('<br />', $volumes);
+                    $volumes = implode('<br />', $volumeDisplay);
                 }
 
                 $containerExcludes = implode("\r\n", $containerSetting['exclude']);
@@ -1014,7 +1059,8 @@ HTML;
     }
 
     function addVolumeToExclude(element) {
-        $path = $(element).text();
+        // Use the mapped path for exclusions since that's what actually gets backed up
+        $path = $(element).data('mapped') || $(element).data('original') || $(element).text();
         $excludeTextarea = $('#' + $(element).data('container') + '_exclude');
 
         if ($excludeTextarea.val().split(/\r?\n|\r|\n/g).includes($path)) { // If existing inside textarea
@@ -1078,7 +1124,8 @@ HTML;
 
         $("code[data-container]").each(function () {
             let container = $(this).data('container');
-            let mapping = $(this).text();
+            // Use the mapped path for duplicate checking since that's what gets backed up
+            let mapping = $(this).data('mapped') || $(this).data('original') || $(this).text();
 
             if ($(this).data('excluded')) {
                 console.debug('Ignore ' + mapping + ': Excluded!');
@@ -1104,7 +1151,8 @@ HTML;
 
         affectedMappings.forEach(function (element) {
             let codeElems = $('code[data-container]').filter(function () {
-                return $(this).text() === element;
+                let mapping = $(this).data('mapped') || $(this).data('original') || $(this).text();
+                return mapping === element;
             });
             console.debug("Affected (filtered) code elems", codeElems);
             codeElems.each(function () {


### PR DESCRIPTION
This feature allows the user to map container volumes to different paths. This is useful if your backup strategy includes creating BTRFS snapshots, where the path you want to include in your backup is not the actual container volume, but the snapshotted one.